### PR TITLE
Explicitly declare each composite action directory

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,24 @@ version: 2
 updates:
   - package-ecosystem: "github-actions"
     target-branch: "main"
-    directory: "/"
+    directory: "/capistrano-staging-deploy"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    target-branch: "main"
+    directory: "/run-overcommit"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    target-branch: "main"
+    directory: "/setup-db-and-run-rspec"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    target-branch: "main"
+    directory: "/setup-rails-dependencies"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
This workaround seems to work, and currently dependabot is not raising PRs on actions we only know are outdated from running the workflows that are using these composite actions.